### PR TITLE
Tidies Community Message – removes inline CSS, adopts accessible accordion

### DIFF
--- a/src/CRM/CommunityMessagesBundle/Resources/views/Default/tips.html.twig
+++ b/src/CRM/CommunityMessagesBundle/Resources/views/Default/tips.html.twig
@@ -3,7 +3,7 @@
 <div class="messages help civicrm-community-messages" style="display:none">
   <a href="javascript:void(0)" title="Dismiss" class="crm-i fa-times float-right civicrm-community-message-dismiss"></a>
   <details>
-    <summary><strong>{{ title|raw }}</strong></summary>
+    <summary><strong>{{ title|raw }}…</strong></summary>
     <div class="crm-accordion-body">{{ body|raw }}</div>
   </details>
 </div>

--- a/src/CRM/CommunityMessagesBundle/Resources/views/Default/tips.html.twig
+++ b/src/CRM/CommunityMessagesBundle/Resources/views/Default/tips.html.twig
@@ -1,44 +1,11 @@
-<style type="text/css">
-  div.civicrm-community-messages {
-    border: 2px solid #7dc857;
-    padding: 10px;
-    position: relative;
-  }
-  div.civicrm-community-messages .crm-collapsible .collapsible-title {
-    font-weight: normal;
-    color: #056085;
-  }
-  div.civicrm-community-messages .crm-collapsible .collapsible-title:hover {
-    color: #003676;
-  }
-  div.civicrm-community-messages a.civicrm-community-message-dismiss {
-    position: absolute;
-    opacity: .6;
-    top: 2px;
-    right: 2px;
-  }
-  div.civicrm-community-messages a.civicrm-community-message-dismiss:hover {
-    opacity: 1;
-  }
-  div.civicrm-community-messages .collapsed .collapsible-title div {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  div.civicrm-community-messages .collapsed .collapsible-title div:after {
-    content: " \2026";
-  }
-</style>
-
 {# Messages are intiailly hidden then shown via js instead of the other way around to avoid initial flash #}
-<div style="display:none" class="civicrm-community-messages">
-  <a href="javascript:void(0)" class="civicrm-community-message-dismiss ui-icon ui-icon-circle-close" title="Dismiss"></a>
-  <div class="crm-collapsible collapsed">
-    <div class="collapsible-title">
-      <div>{{ title|raw }}</div>
-    </div>
-    <div style="margin-top: 1em;">{{ body|raw }}</div>
-  </div>
+
+<div class="messages help civicrm-community-messages" style="display:none">
+  <a href="javascript:void(0)" title="Dismiss" class="crm-i fa-times float-right civicrm-community-message-dismiss"></a>
+  <details>
+    <summary><strong>{{ title|raw }}</strong></summary>
+    <div class="crm-accordion-body">{{ body|raw }}</div>
+  </details>
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
Uses CiviCRM classes to allow removal of inline CSS. Swaps the crm-collapsible script with details/summary. Needs testing before merging.

## Before
Expand caret is on its own line, the close icon is aligned top right, it doesn't match other Civi alert styles, accordion isn't keyboard accessible.

<img width="1083" alt="image" src="https://github.com/civicrm/civicrm-community-messages/assets/1175967/37b6cfb3-7b77-4a54-896f-74f5c18ca164">
<img width="1082" alt="image" src="https://github.com/civicrm/civicrm-community-messages/assets/1175967/e0c7aa90-5bbf-40f6-a1b7-909205bb0aa0">

## After
<img width="1081" alt="image" src="https://github.com/civicrm/civicrm-community-messages/assets/1175967/19cdb95d-de0c-4f9b-8ce0-6ebc1f0fdbf6">
<img width="1080" alt="image" src="https://github.com/civicrm/civicrm-community-messages/assets/1175967/6463052a-10f2-49fe-8499-5851bb14fe20">

## Notes
The original has some inline JS to hide the message at first, and to dismiss it on clicking the X. That's been kept here, but there may be less bespoke ways of doing that (for e.g. using the Bootstrap Alert / Dismissable component)).

The appearance is changed in this PR to match other Civi alerts.

Am not sure how to test this - so please don't merge without a test / merge-ready label.